### PR TITLE
Updated the links to this repo in patcher.sh; Fixed line ending issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+patcher.sh eol=lf

--- a/Unix-like/patcher.sh
+++ b/Unix-like/patcher.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 
-sharpii="https://github.com/RiiConnect24/auto-wiiware-patcher/raw/master/bin/sharpii"
-wiiwarepatcher="https://github.com/RiiConnect24/auto-wiiware-patcher/raw/master/bin/wiiwarepatcher"
-lzx="https://github.com/RiiConnect24/auto-wiiware-patcher/raw/master/bin/lzx"
+sharpii="https://github.com/RiiConnect24/WiiWare-Patcher/raw/master/bin/sharpii"
+wiiwarepatcher="https://github.com/RiiConnect24/WiiWare-Patcher/raw/master/bin/wiiwarepatcher"
+lzx="https://github.com/RiiConnect24/WiiWare-Patcher/raw/master/bin/lzx"
 
 #detect architecture to download the correct binary for sharpii, lzx and wiiwarepatcher
 if [[ -z "$(uname -s | grep 'Darwin')" ]]; then


### PR DESCRIPTION
***PR Desc: Updated links hardcoded in patcher.sh; Fixed Line ending issues***

For the Unix-Like patcher: Approximately 4 days ago from what I can tell this repo was renamed (`auto-wiiware-patcher -> WiiWare-Patcher`). While the previous [url](https://github.com/RiiConnect24/auto-wiiware-patcher) still redirects to the newly renamed repo, it's best not to rely on this and to update the link in the patcher as needed executables (Sharpii, lzx, wiiwarepatcher) have this link hardcoded.

This does *not* affect the batch script or the compiled patcher executable, as neither have this link hard-coded, or if they did it was already updated.

**Operating Systems Edited: MAC/LINUX**