### PR TITLE
Testing Needed: Fix exclamation points in file names breaking the patcher

### DIFF
--- a/Windows/WiiWarePatcher.bat
+++ b/Windows/WiiWarePatcher.bat
@@ -1,7 +1,5 @@
 @echo off
-REM --- Important for file counter to work ---
-setlocal ENABLEDELAYEDEXPANSION
-rem ---
+
 cd /d "%~dp0"
 set currentPath=%cd%
 goto begin
@@ -59,6 +57,12 @@ set /a errorwinxp=0
 set /a updateserver=1
 goto choose_patch_type
 
+rem This is called to remove exclamation points from file names.
+rem Exclamation points break the script when ENABLEDELAYEDEXPANSION is set for the file counter.
+:RemoveExclamationPoints
+set "filename=%~n1"
+ren %1 "%filename:!=%%~x1"
+goto :EOF
 
 :begin_main
 if %aio_assisted%==1 exit
@@ -790,11 +794,19 @@ if not exist temp md temp
 if not exist wiimmfi-wads md wiimmfi-wads
 if not exist backup-wads md backup-wads
 
+rem Removes Exclamation Points for ENABLEDELAYEDEXPANSION
+for %%r in ("*.wad") do call :RemoveExclamationPoints "%%r"
+
+rem --- Important for file counter to work ---
+setlocal ENABLEDELAYEDEXPANSION
+rem ---
+
 for %%f in ("*.wad") do (
 cls
 echo %header_loop%
 echo ------------------------------------------------------------------------------------------------------------------------------
 echo.
+echo %%~nf
 echo Patching file [!patching_file!] out of [%file_counter%]
 echo File name: %%~nf
 echo.

--- a/Windows/WiiWarePatcher.bat
+++ b/Windows/WiiWarePatcher.bat
@@ -806,7 +806,6 @@ cls
 echo %header_loop%
 echo ------------------------------------------------------------------------------------------------------------------------------
 echo.
-echo %%~nf
 echo Patching file [!patching_file!] out of [%file_counter%]
 echo File name: %%~nf
 echo.


### PR DESCRIPTION
***PR Desc: Fix exclamation points in file names breaking the patcher***

Fixes #28 

**Problem:**
A fairly long standing bug where the patcher breaks with exclamation points due to having `ENABLEDELAYEDEXPANSION` set in the patcher for the file counter has been known, and I've been trying to fix it for a few hours now. I have found no other special characters that exhibit this behavior, but if another shows up it will only take one line to fix.

**Solution:**
After some tinkering, I figured out that we are able to move the `ENABLEDELAYEDEXPANSION` setlocal call to right before it's needed in the patcher, and before that run a few commands to remove exclamation points from the file names of any thing matching `*.wad` in the patcher's folder. 

**Testing:**
I know I just got write access to this repo, but while not much was added overall I *Do* still want to make sure this is air-tight on other systems, as there were a few issues to get it working for mine, so I would like a bit more testing via this PR first. I'm requesting a PR review from @KcrPL specifically as they opened #28.

To test: Have one (or multiple) files with "!" in their names, the patcher shouldn't break and the files should be renamed. Ex. `Filename!.wad -> Filename.wad`

**Operating Systems Edited: WINDOWS**