### PR TITLE
Include Wiimmfi patches from v0.7.5

### DIFF
--- a/src/wiiwarepatcher.cpp
+++ b/src/wiiwarepatcher.cpp
@@ -74,13 +74,13 @@ int do_new_wiimmfi(char *addr, int len) {
 
         // Patch the User-Agent so Wiimmfi knows this game has been patched. 
         // Note: The letter and the first digit in this User-Agent specifies which patcher patched the WiiWare game.
-        // Please leave that as is ("J-2") and do not change this without talking to Leseratte beforehand.
+        // Please leave that as is ("J-3") and do not change this without talking to Leseratte beforehand.
         if (memcmp(cur, "User-Agent\x00\x00RVL SDK/", 20) == 0) {
 
             if (hasGT2Error) 
-                memcpy(cur + 12, "J-2-1\x00", 6); 
+                memcpy(cur + 12, "J-3-1\x00", 6); 
             else
-                memcpy(cur + 12, "J-2-0\x00", 6); 
+                memcpy(cur + 12, "J-3-0\x00", 6); 
             
         }
 
@@ -148,6 +148,8 @@ int do_new_wiimmfi(char *addr, int len) {
                                 successful_patch_p2p++;
                             }
                             if (found_opcode_chain_P2P_v2) {
+
+                                loadedDataReg = 12;
                                 
                                 *(int *)(cur + 0x14) = htonl(0x88010011 | (comparisonDataReg << 21)); 
                                 *(int *)(cur + 0x18) = htonl(0x28000080 | (comparisonDataReg << 16)); 


### PR DESCRIPTION
***PR Desc: ***
**Operating Systems Edited: ALL/MAC/LINUX/WINDOWS**

Another week, another update ... let's hope that this is finally the last one.

Apparently the code in some games re-uses registers in a weird way which sometimes made matchmaking with more than 3+ players break in a bunch of games.

I've tested this bugfix on Friday with larsenv in a bunch of affected games (OnSlaught, Fortune Street and UNO) and they were all fixed with this patch. 

Most likely these are all the WiiWare games that are affected by this bug and would need to be re-patched when this is merged. WiiWare games that are not on this list will not need to be re-patched again if already patched with the previous version.  
```
bejeweled2wii.tab
shikagariwii.tab
derbydogwii.tab
idraculawii.tab
fantcubewii.tab
gradiusrbwii.tab
hoopworldwii.tab
jyankenparwii.tab
monkmayhemwii.tab
megaman10wii.tab
seafarmwii.tab
othellowii.tab
phybaltraiwii.tab
puyowii.tab
puyo2wii.tab
rubikguidewii.tab
sneezieswiiw.tab
sonicdlwii.tab
supsf2wii.tab
keenracerswii.tab
tvshwking2wii.tab
tarlawdartwii.tab
surkatamarwii.tab
unowii.tab
escviruswii.tab
micchannelwii.tab
```